### PR TITLE
Improve test setup: add Makefile for "make test"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/sensible/
+test/vader/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: vim
 
 before_script: |
-  git clone https://github.com/junegunn/vader.vim.git vader
-  git clone https://github.com/tpope/vim-sensible.git sensible
-
   hg clone https://code.google.com/p/vim/
   cd vim
   # ./configure --with-features=huge --enable-rubyinterp --enable-pythoninterp
@@ -13,11 +10,4 @@ before_script: |
   cd -
 
 script: |
-  /usr/local/bin/vim -Nu <(cat << VIMRC
-  set rtp+=vader
-  set rtp+=sensible
-  set rtp+=textobj-user
-  set rtp+=.
-  set rtp+=textobj-user/after
-  set rtp+=./after
-  VIMRC) -c 'Vader! test/*' > /dev/null
+  make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+test/build/vader:
+	git clone https://github.com/junegunn/vader.vim.git $@
+
+test/build/sensible:
+	git clone https://github.com/tpope/vim-sensible.git $@
+
+test/build/textobj-user:
+	git clone https://github.com/kana/vim-textobj-user $@
+
+test: test/build/vader test/build/sensible test/build/textobj-user
+	cd test \
+		&& HOME=/dev/null vim -Nu vimrc -c "Vader! *" > /dev/null
+
+.PHONY: test

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,0 +1,8 @@
+set rtp+=build/vader
+set rtp+=build/sensible
+set rtp+=build/textobj-user
+set rtp+=..
+set rtp+=build/textobj-user/after
+set rtp+=../after
+" Do not create .viminfo file.
+set viminfo=


### PR DESCRIPTION
This auto-installs dependencies.

Additional fixes:
- Set $HOME before calling vim, otherwise a user's plugins would be
  loaded, too.
- Install textobj-user (used in vimrc, but not on travis (yet?!)).
- Set `viminfo=`.

Fixes https://github.com/idbrii/vim-endoscope/issues/1
